### PR TITLE
Tambah website (docsify)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta charset="UTF-8">
+  <title>Daftar API Lokal Indonesia</title>
+  <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
+</head>
+<body>
+  <noscript>This page requires JavaScript to work, please enable it or just read it on <a href="https://github.com/farizdotid/DAFTAR-API-LOKAL-INDONESIA">Here</a>.</noscript>
+  <div id="app">Loading...</div>
+  <script>
+    window.$docsify = {
+      name: 'Daftar API Lokal Indonesia',
+      repo: 'farizdotid/DAFTAR-API-LOKAL-INDONESIA',
+      search: ['/'],
+      relativePath: true,
+    }
+  </script>
+  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+  <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Terinspirasi dari sini https://github.com/ripienaar/free-for-dev.
Sepertinya bakal lebih oke jika daftar api lokal indonesia ini bisa dilihat dari website.
Kia pakai https://docsify.js.org saja, tanpa konfigurasi aneh2, dari readme.md lansung di parsing ke html.

Jadinya kurang lebih kaya gini: 

![image](https://user-images.githubusercontent.com/20186786/99153054-90db1380-26d8-11eb-9eec-afd9dcab7c34.png)

Nanti tinggal di sesuaikan saja utk domain di `github-pages` nya.

Cek: https://lakuapik.github.io/DAFTAR-API-LOKAL-INDONESIA/
