### PR TITLE
add web API of Badan Pusat Statistik RI

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -20,6 +20,7 @@ This file is translation from Original (Bahasa Indonesia).
     - [Book](#book)
     - [Courier](#courier)
     - [Daily Life](#daily-life)
+    - [Data](#data)
     - [E-Commerce](#e-commerce)
     - [Entertainment](#entertainment)
     - [Event](#event)
@@ -61,6 +62,12 @@ This file is translation from Original (Bahasa Indonesia).
 | API Name        | Developer | URL | Status  | Description | `Auth` |
 | --------------- |:---------:|:---:|:-------:|:----------|:------:|
 | Cerpenmu.com API| Abdul Muttaqin | [Link](https://fdci.se/cerpenmu-com-api-random-cerpen/) | `Active` | Get random short stories from cerpenmu.com  | No |
+
+### Data
+
+| Nama API                     |     Developer      |                                       URL                                       | Status  | Deskripsi                                                                                                         |  `Auth`  |
+| ---------------------------- | :----------------: | :-----------------------------------------------------------------------------: | :-----: | :---------------------------------------------------------------------------------------------------------------- | :------: |
+| Web API Badan Pusat Statistik RI | Badan Pusat Statistik | [Link](https://webapi.bps.go.id/developer/) | `Active` | Official API from Badan Pusat Statistik RI to access data and statistics products of BPS RI | `apiKey` |
 
 ### E-Commerce
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ Kumpulan API tentang data dan informasi di Indonesia
 ## Daftar Isi
 
 - [Daftar API Lokal Indonesia](#daftar-api-lokal-indonesia)
-- [Daftar dalam bahasa lain](#daftar-dalam-bahasa-lain)
+  - [Daftar dalam bahasa lain](#daftar-dalam-bahasa-lain)
   - [Daftar Isi](#daftar-isi)
   - [Daftar API](#daftar-api)
     - [Informasi Umum](#informasi-umum)
     - [Berita](#berita)
     - [Buku](#buku)
-    - [E-Commerce](#e-commerce)
+    - [Data](#data)
+    - [_E-Commerce_](#e-commerce)
     - [Finansial](#finansial)
     - [Forum](#forum)
     - [Hiburan](#hiburan)
@@ -34,10 +35,10 @@ Kumpulan API tentang data dan informasi di Indonesia
     - [Ramalan Cuaca](#ramalan-cuaca)
     - [Sertifikasi](#sertifikasi)
     - [Utilitas](#utilitas)
-  - [Crypto](#crypto)
+    - [Crypto](#crypto)
   - [Kontak](#kontak)
   - [:fire: TERIMAKASIH :fire:](#fire-terimakasih-fire)
-- [Lisensi](#lisensi)
+  - [Lisensi](#lisensi)
 
 ## Daftar API
 
@@ -77,6 +78,12 @@ Kumpulan API tentang data dan informasi di Indonesia
 | Quran API ID                  |                 R.M. Reza                 |                         [Link](https://github.com/renomureza/quran-api-id)                         | `Aktif` | REST API Al-Quran Indonesia dengan terjemahan, tafsir (Kemenag, Quraish Shihab, Al-Jalalain), audio murottal (per surah dan ayat dari 6 qori), random ayat, dll. |  Tidak   |
 | Unofficial Gramedia Ebooks    |                 Yusuf T.                  |                      [Link](https://github.com/yusuftaufiq/laravel-books-api)                      | `Aktif` | Unofficial REST API yang menyediakan daftar buku digital dari [Gramedia](https://ebooks.gramedia.com/) melalui web scraping.                                     | `apiKey` |
 | Holy Quran API                |                Kang Cahya                 |               [Link](https://github.com/dyazincahya/quran-api-with-php-codeigniter)                | `Aktif` | Holy Quran API - 6236 verses, 114 surah, 30 Juz                                                                                                                  |  Tidak   |
+
+### Data
+
+| Nama API                     |     Developer      |                                       URL                                       | Status  | Deskripsi                                                                                                         |  `Auth`  |
+| ---------------------------- | :----------------: | :-----------------------------------------------------------------------------: | :-----: | :---------------------------------------------------------------------------------------------------------------- | :------: |
+| Web API Badan Pusat Statistik RI | Badan Pusat Statistik | [Link](https://webapi.bps.go.id/developer/) | `Aktif` | API untuk akses data dan produk statistik Badan Pusat Statistik RI | `apiKey` |
 
 ### _E-Commerce_
 


### PR DESCRIPTION
**API Name**: Web API Badan Pusat Statistik
**Developer**: Badan Pusat Statistik
**API Docs**: https://webapi.bps.go.id/documentation/
**Status**: Active
**Description**: The BPS APIs provides programmatic access to read BPS data. User can read about Publication, Press Release, BPS Event, and a lot of various kinds of data presented in the static table and dynamic tables. The BPS API identifies user with key token. User can get the key token from API-Portal website. Every user can get two until three key token to access the API. Responses are available in JSON.

## Penjelasan
Untuk menggunakan REST API dari BPS, developer terlebih dahulu harus mendaftar untuk mendapatkan apiKey secara gratis. selengkapnya bisa melakukan penjelajahan di dokumentasi link diatas.