### PR TITLE
Menambah Python 3 API wrapper PDDIKTI

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Kumpulan API tentang data dan informasi di Indonesia
 | Data Sekolah API           | Ahmad Ramadhan | [Link](https://github.com/semogaBermanfaat-AhmadRamadhan/dataSekolahNegeriIndonesia) | `Aktif` | Data Sekolah Negeri di Indonesia       | Tidak  |
 | API Data Sekolah Indonesia |     Alwan      |              [Link](https://github.com/wanrabbae/api-sekolah-indonesia)              | `Aktif` | Data Data Sekolah di Indonesia Lengkap | Tidak  |
 | Data Mahasiswa Indonesia | Kemendikbud | [Link](https://api-frontend.kemdikbud.go.id/hit_mhs/abiel%20zulio%20maseida) | `Aktif` | Data mahasiswa se-Indonesia mencakupi nama lengkap, universitas, dan program studi | Tidak |
+| Python 3 API wrapper PDDIKTI | IlhamRisky | [Link](https://github.com/IlhamriSKY/PDDIKTI-kemdikbud-API) | `Aktif` | Python API wrapper, yang mengambil data dari web PDDIKTI, terdiri dari data Universitas, Program Studi, Dosen, Mahasiswa/Alumni, Berita, Laporan, Dll  | Tidak |
 
 ### Ramalan Cuaca
 


### PR DESCRIPTION
Berupa List API PDDIKTI yang sudah dikumpulkan di package python yang mengambil data dari web PDDIKTI, terdiri dari data Universitas, Program Studi, Dosen, Mahasiswa/Alumni, Berita, Laporan, Dll.