### PR TITLE
Add AnimeAPI to Entertainment/Hiburan

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -85,6 +85,7 @@ This file is translation from Original (Bahasa Indonesia).
 | Tanggal Lahiran Pasaran Zodiak | iBachor | [Link](https://github.com/bachors/apiapi#tanggal-lahiran-pasaran-zodiak) | `Active` | Zodiac checker | No |
 | KyokoAPI | Elliottophellia | [Link](https://kyoko.rei.my.id) | `Active` | Generate Random Anime Pictures & Quotes,Trace Anime Screenshot To Find The Source,And Find Detail Information About Any Anime Titles! | No |
 | Wibu API | Yoga Pranata Damanik | [Link](https://wibu-api.eu.org) | `Active` | Multi API: Anime, Donghua, Hentai, Manga, Doujin, Anime Opening & Ending, Lk21, Google, Facebook, Download link scraper, NSFW & Adult content, etc. | No |
+| AnimeAPI | nattadasu | [Link](https://animeapi.my.id) | `Aktif` | RESTful API for ID relational mapping across 15 anime databases | No |
 
 ### Event
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -85,7 +85,7 @@ This file is translation from Original (Bahasa Indonesia).
 | Tanggal Lahiran Pasaran Zodiak | iBachor | [Link](https://github.com/bachors/apiapi#tanggal-lahiran-pasaran-zodiak) | `Active` | Zodiac checker | No |
 | KyokoAPI | Elliottophellia | [Link](https://kyoko.rei.my.id) | `Active` | Generate Random Anime Pictures & Quotes,Trace Anime Screenshot To Find The Source,And Find Detail Information About Any Anime Titles! | No |
 | Wibu API | Yoga Pranata Damanik | [Link](https://wibu-api.eu.org) | `Active` | Multi API: Anime, Donghua, Hentai, Manga, Doujin, Anime Opening & Ending, Lk21, Google, Facebook, Download link scraper, NSFW & Adult content, etc. | No |
-| AnimeAPI | nattadasu | [Link](https://animeapi.my.id) | `Aktif` | RESTful API for ID relational mapping across 15 anime databases | No |
+| AnimeAPI | nattadasu | [Link](https://animeapi.my.id) | `Active` | RESTful API for ID relational mapping across 15 anime databases | No |
 
 ### Event
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Kumpulan API tentang data dan informasi di Indonesia
 | Quotes Generator API                       |   Irfan Akbari Habibi  |     [Link](https://github.com/Irfanakbari/quote-generator-api)      | `Aktif` | API untuk Dapatkan Random Quotes Harian                                        |       Tidak        |
 | Wibu API | Yoga Pranata Damanik | [Link](https://wibu-api.eu.org) | `Aktif` | Multi API: Anime, Donghua, Hentai, Manga, Doujin, Anime Opening & Ending, Lk21, Google, Facebook, Download link scraper, NSFW & Konten dewasa, dll. | Tidak |
 | Flamescans Manga Scraper (EN) | KevinNVM | [Link](https://github.com/KevinNVM/flamescans-manga-scraper) | `Aktif` | Flamescans Manga Scraper English Language | Tidak |
+| AnimeAPI | nattadasu | [Link](https://animeapi.my.id) | `Aktif` | REST API untuk pemetaan relasi ID antara 15 situs database anime lokal dan luar negeri | Tidak |
 
 ### Jasa Pengiriman
 


### PR DESCRIPTION
## Informasi API

**Nama API**: AnimeAPI
**Developer**: @nattadasu
**API Endpoint/Dokumentasi**: https://animeapi.my.id \| https://github.com/nattadasu/animeApi
**Status**: Aktif
**Deskripsi**: REST API untuk pemetaan relasi ID antara 15 situs database anime lokal dan luar negeri | _RESTful API for ID relational mapping across 15 anime databases_
**Auth**: Tidak Ada

### Penjelasan API

AnimeAPI merupakan layanan REST API gratis dan terbuka yang membantu pengguna dalam mendapatkan ID entri/judul sebuah acara animasi Jepang, China, dan Korea dari salah satu situs pangkalan data/*database* ke situs lainnya secara akurat. Pengguna yang tertarik menggunakan API ini dapat mengunjungi repositori utama untuk dokumentasi lebih lanjut.

_AnimeAPI is a free and open-source RESTful API service that assists user looking up title ID of Chinese, Japanese, and Korean animation from one database site to other accurately. Documentation is available on main repository of the service._
